### PR TITLE
Fix call for ContextualModelTransformer

### DIFF
--- a/spec/ModelTransformer/ModelTransformerSpec.php
+++ b/spec/ModelTransformer/ModelTransformerSpec.php
@@ -245,6 +245,19 @@ class ModelTransformerSpec extends ObjectBehavior
             ->shouldBe($contextualModelTransformer);
     }
 
+    public function it_should_not_call_support_in_contextual_model_transformer_without_context(
+        ContextualModelTransformerInterface $contextualModelTransformer
+    )
+    {
+        $contextualModelTransformer
+            ->supports(new \stdClass(), SomeClass::class)
+            ->shouldNotBeCalled();
+
+        $this->addModelTransformer($contextualModelTransformer);
+
+        $this->findSupportedModelTransformer(new \stdClass(), SomeClass::class);
+    }
+
     public function it_should_not_pass_context_to_model_transformer(
         ModelTransformerInterface $modelTransformer,
         ContextInterface $context

--- a/src/ModelTransformer/ModelTransformer.php
+++ b/src/ModelTransformer/ModelTransformer.php
@@ -195,7 +195,7 @@ class ModelTransformer implements ModelTransformerInterface
         }
 
         foreach ($this->getModelTransformers() as $modelTransformer) {
-            if (($modelTransformer instanceof ContextualModelTransformerInterface) && $modelTransformer->supports($object, $targetClass, $context)) {
+            if ($context != null && ($modelTransformer instanceof ContextualModelTransformerInterface) && $modelTransformer->supports($object, $targetClass, $context)) {
                 return $modelTransformer;
             }
 


### PR DESCRIPTION
It should not call "support" method with empty Context